### PR TITLE
Updated configs and 'register_types.h' with 4.1 changes

### DIFF
--- a/demo/addons/geodot/geodot.gdextension
+++ b/demo/addons/geodot/geodot.gdextension
@@ -1,6 +1,7 @@
 [configuration]
 
 entry_symbol = "geodot_library_init"
+compatibility_minimum = 4.1
 
 [libraries]
 

--- a/demo/addons/geodot/plugin.cfg
+++ b/demo/addons/geodot/plugin.cfg
@@ -3,5 +3,5 @@
 name="Geodot"
 description="Plugin for loading geospatial data."
 author="BOKU-ILEN"
-version="4.0"
+version="4.1"
 script="geodot-entry.gd"

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -30,10 +30,10 @@ void unregister_geodot_types(ModuleInitializationLevel p_level) {
 
 extern "C" {
 
-GDExtensionBool GDE_EXPORT geodot_library_init(const GDExtensionInterface *p_interface,
+GDExtensionBool GDE_EXPORT geodot_library_init(GDExtensionInterfaceGetProcAddress p_get_proc_address,
                                                const GDExtensionClassLibraryPtr p_library,
                                                GDExtensionInitialization *r_initialization) {
-    godot::GDExtensionBinding::InitObject init_obj(p_interface, p_library, r_initialization);
+    godot::GDExtensionBinding::InitObject init_obj(p_get_proc_address, p_library, r_initialization);
 
     // Initialize the custom libraries
     RasterTileExtractor::initialize();


### PR DESCRIPTION
- Adapted the submodule (`godot-cpp`) to now look at the `4.1` branch
- Change: changed registrarion params and GDExtension configs
  Changed one of the parameters in the classes' registrarion in
    register_types.h (changed in 4.1) and changed the release version of the plugin in the config file.
    
  Also added a minimum_compatible_version, since it's a new (required) parameter for the config, otherwise Godot would not accept the plugin.