### PR TITLE
Added extra functions to extract individual layers from GDALDatasets and more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build/
 **/.sconsign.dblite
 **/.vscode/
 demo/.import/
+**/.godot/*

--- a/demo/geodata/vienna-test-ortho.jpg.import
+++ b/demo/geodata/vienna-test-ortho.jpg.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/vienna-test-ortho.jpg-5325b663943c1c2e87bc1a6
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/demo/project.godot
+++ b/demo/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="Demo"
 run/main_scene="res://RasterDemo.tscn"
-config/features=PackedStringArray("4.0")
+config/features=PackedStringArray("4.1")
 config/icon="res://icon.png"
 
 [autoload]

--- a/src/geodata.cpp
+++ b/src/geodata.cpp
@@ -435,7 +435,7 @@ void GeoRasterLayer::set_value_at_position(double pos_x, double pos_y, Variant v
 
         delete[] values;
     } else {
-        // TODO: Output an error since there was apparently a type mis-match
+        std::cout << "Type mismatch: value of type " << value.get_type() << " and dataset of type " << get_format() << std::endl;
     }
 
     dataset->dataset->FlushCache();
@@ -527,7 +527,6 @@ void GeoRasterLayer::overlay_image_at_position(double pos_x, double pos_y, Ref<I
             set_value_at_position(pos_in_image_x, pos_in_image_y, value);
         }
     } else {
-        // TODO: Output an error since there was apparently a type mis-match
         std::cout << "Type mismatch: image of type " << image->get_format() << " and dataset of type " << get_format() << std::endl;
     }
 }

--- a/src/geodata.cpp
+++ b/src/geodata.cpp
@@ -24,7 +24,7 @@ void GeoDataset::_bind_methods() {
     ClassDB::bind_method(D_METHOD("get_raster_layers"), &GeoDataset::get_raster_layers);
     ClassDB::bind_method(D_METHOD("get_raster_layers_by_band"), &GeoDataset::get_raster_layers_by_band);
     ClassDB::bind_method(D_METHOD("get_feature_layers"), &GeoDataset::get_feature_layers);
-    ClassDB::bind_method(D_METHOD("get_raster_layer", "name", "band_index"), &GeoDataset::get_raster_layer);
+    ClassDB::bind_method(D_METHOD("get_raster_layer", "name", "band_index"), &GeoDataset::get_raster_layer, DEFVAL(1));
     ClassDB::bind_method(D_METHOD("get_feature_layer", "name"), &GeoDataset::get_feature_layer);
     ClassDB::bind_method(D_METHOD("get_raster_count"), &GeoDataset::get_raster_count);
     ClassDB::bind_method(D_METHOD("load_from_file", "file_path", "write_access"),

--- a/src/geodata.h
+++ b/src/geodata.h
@@ -135,7 +135,7 @@ class EXPORT GeoRasterLayer : public Resource {
     /// index will (probably erroneously) be assigned index 1.
     /// TODO: Make sure that all layers get a correctly assigned index.
     Ref<GeoImage> get_band_image(double top_left_x, double top_left_y, double size_meters, int img_size,
-                            int interpolation_type);
+                            int interpolation_type, int band_index);
 
     /// Returns the value in the GeoRasterLayer at exactly the given position.
     /// Note that when reading many values from a confined area, it is more efficient to call
@@ -197,22 +197,12 @@ class EXPORT GeoRasterLayer : public Resource {
     /// Not exposed to Godot since it should never construct GeoFeatureLayers by hand.
     void set_origin_dataset(Ref<GeoDataset> dataset);
 
-    /// Get the band_index that this raster_layer is set to.
-    int get_band_index();
-
-    /// @brief Sets the band_index for this layer.
-    ///
-    /// Not exposed to Godot, since it's only meant for cloning/internal use.
-    void set_band_index(int band_index);
-
     bool write_access;
 
   private:
     Ref<GeoDataset> origin_dataset;
     std::shared_ptr<NativeDataset> dataset;
     ExtentData extent_data;
-    // The Band (in the Raster) that this GeoRasterLayer represents
-    int band_index;
 };
 
 /// A dataset which contains layers of geodata.
@@ -239,22 +229,13 @@ class EXPORT GeoDataset : public Resource {
     /// Return all GeoRasterLayers objects for this dataset.
     Array get_raster_layers();
 
-    /// Like `get_raster_layers`, but instead of looking for them by name, looking by index
-    Array get_raster_layers_by_band();
-
     /// Return all GeoFeatureLayer objects for this dataset.
     Array get_feature_layers();
 
     /// Returns a GeoRasterLayer object of the layer within this dataset with
     /// the given name. It is recommended to check the validity of the returned
     /// object with GeoRasterLayer::is_valid().
-    Ref<GeoRasterLayer> get_raster_layer(String name, int band_index);
-
-    /// Like `get_raster_layer` returns a GeoRasterLayer.
-    /// Different to `get_raster_layer` it not attempt to extract (possibly)
-    /// non-existent SUBDATASETS from the main Dataset and just sets the main
-    /// dataset as the native dataset of the Layer.
-    Ref<GeoRasterLayer> get_raster_band(String description, int band_index);
+    Ref<GeoRasterLayer> get_raster_layer(String name);
 
     /// Returns a GeoFeatureLayer object of the layer within this dataset with
     /// the given name. It is recommended to check the validity of the returned

--- a/src/geodata.h
+++ b/src/geodata.h
@@ -129,6 +129,14 @@ class EXPORT GeoRasterLayer : public Resource {
     Ref<GeoImage> get_image(double top_left_x, double top_left_y, double size_meters, int img_size,
                             int interpolation_type);
 
+    /// Like get_image but only returns the GeoImage of a single Band.
+    /// Each GeoRasterLayer has an index that represents the RasterBand index from where the
+    /// the information is taken in the Dataset. Bands that have been initialized without a specific
+    /// index will (probably erroneously) be assigned index 1.
+    /// TODO: Make sure that all layers get a correctly assigned index.
+    Ref<GeoImage> get_band_image(double top_left_x, double top_left_y, double size_meters, int img_size,
+                            int interpolation_type);
+
     /// Returns the value in the GeoRasterLayer at exactly the given position.
     /// Note that when reading many values from a confined area, it is more efficient to call
     /// get_image and read the pixels from there.
@@ -189,12 +197,22 @@ class EXPORT GeoRasterLayer : public Resource {
     /// Not exposed to Godot since it should never construct GeoFeatureLayers by hand.
     void set_origin_dataset(Ref<GeoDataset> dataset);
 
+    /// Get the band_index that this raster_layer is set to.
+    int get_band_index();
+
+    /// @brief Sets the band_index for this layer.
+    ///
+    /// Not exposed to Godot, since it's only meant for cloning/internal use.
+    void set_band_index(int band_index);
+
     bool write_access;
 
   private:
     Ref<GeoDataset> origin_dataset;
     std::shared_ptr<NativeDataset> dataset;
     ExtentData extent_data;
+    // The Band (in the Raster) that this GeoRasterLayer represents
+    int band_index;
 };
 
 /// A dataset which contains layers of geodata.
@@ -221,13 +239,22 @@ class EXPORT GeoDataset : public Resource {
     /// Return all GeoRasterLayers objects for this dataset.
     Array get_raster_layers();
 
+    /// Like `get_raster_layers`, but instead of looking for them by name, looking by index
+    Array get_raster_layers_by_band();
+
     /// Return all GeoFeatureLayer objects for this dataset.
     Array get_feature_layers();
 
     /// Returns a GeoRasterLayer object of the layer within this dataset with
     /// the given name. It is recommended to check the validity of the returned
     /// object with GeoRasterLayer::is_valid().
-    Ref<GeoRasterLayer> get_raster_layer(String name);
+    Ref<GeoRasterLayer> get_raster_layer(String name, int band_index);
+
+    /// Like `get_raster_layer` returns a GeoRasterLayer.
+    /// Different to `get_raster_layer` it not attempt to extract (possibly)
+    /// non-existent SUBDATASETS from the main Dataset and just sets the main
+    /// dataset as the native dataset of the Layer.
+    Ref<GeoRasterLayer> get_raster_band(String description, int band_index);
 
     /// Returns a GeoFeatureLayer object of the layer within this dataset with
     /// the given name. It is recommended to check the validity of the returned
@@ -242,6 +269,11 @@ class EXPORT GeoDataset : public Resource {
     /// Not exposed to Godot since Godot doesn't know about GDALDatasets - this
     /// is only for internal use.
     void set_native_dataset(std::shared_ptr<NativeDataset> new_dataset);
+
+    /// @brief Get the total amount of raster bands contained in the dataset.
+    /// Returns 0 if dataset is not valid
+    /// @return the total amount of raster bands in the dataset.
+    int get_raster_count();
 
     bool write_access;
 

--- a/src/geodata.h
+++ b/src/geodata.h
@@ -114,6 +114,14 @@ class EXPORT GeoRasterLayer : public Resource {
     /// Returns the Image format which corresponds to the data within this raster layer.
     Image::Format get_format();
 
+    /// @brief Get the total amount of raster bands contained in the layer.
+    /// Returns 0 if layer is not valid
+    /// @return the total amount of raster bands in the layer.
+    int get_band_count();
+
+    /// Returns the descriptions of the individual raster bands as strings in an array.
+    Array get_band_descriptions();
+
     /// Returns the dataset which this layer was opened from or null if it was opened directly, e.g.
     /// from a GeoTIFF.
     Ref<GeoDataset> get_dataset();
@@ -250,11 +258,6 @@ class EXPORT GeoDataset : public Resource {
     /// Not exposed to Godot since Godot doesn't know about GDALDatasets - this
     /// is only for internal use.
     void set_native_dataset(std::shared_ptr<NativeDataset> new_dataset);
-
-    /// @brief Get the total amount of raster bands contained in the dataset.
-    /// Returns 0 if dataset is not valid
-    /// @return the total amount of raster bands in the dataset.
-    int get_raster_count();
 
     bool write_access;
 

--- a/src/geoimage.h
+++ b/src/geoimage.h
@@ -53,6 +53,9 @@ class EXPORT GeoImage : public Resource {
     /// which already have raster data.
     void set_raster(GeoRaster *raster, int interpolation);
 
+    /// Like `set_raster` but uses only the band at band_index from raster.
+    void set_raster_from_band(GeoRaster *raster, int interpolation, int band_index);
+
     /// Get a Godot Image with the GeoImage's data
     Ref<Image> get_image();
 

--- a/src/raster-tile-extractor/GeoRaster.h
+++ b/src/raster-tile-extractor/GeoRaster.h
@@ -4,6 +4,18 @@
 #include "defines.h"
 #include <cstdint>
 
+struct RasterIOHelper {
+    int clamped_pixel_offset_x;
+    int clamped_pixel_offset_y;
+    int min_raster_size; // Currently unused
+    int remainder_x_left;
+    int remainder_y_top;
+    int target_height;
+    int target_width;
+    int usable_height;
+    int usable_width;
+};
+
 // Forward declaration of GDALDataset from <gdal/gdal_priv.h>
 class GDALDataset;
 
@@ -14,7 +26,7 @@ class GeoRaster {
     enum FORMAT { // size (bits)    | data type         |   Number of chanels
         RGB,      //    8           | int               |   3
         RGBA,     //    8           | int               |   4
-        RF,       //    32          | float             |   X >= 1
+        RF,       //    32<=X<=64   | float             |   X >= 1
         BYTE,     //    8           | int               |   X >= 1
         MIXED,    //    8<=X<=64    | int and/or float  |   X >= 2
         UNKNOWN   //    unknown     | unknown           |   X >= 1
@@ -29,7 +41,7 @@ class GeoRaster {
     ~GeoRaster() = default;
 
     static FORMAT get_format_for_dataset(GDALDataset *data);
-
+    
     /// Return the data of the GeoRaster as an array. The array contains type of the raster format
     /// (get_format).
     /// BYTE -> (B)(B)(B) with B of type uint8_t
@@ -39,6 +51,12 @@ class GeoRaster {
     /// @RequiresManualDelete
     void *get_as_array();
 
+    /// @brief Return the data within a single band of the GeoRaster as an array.
+    /// The type of the array can be any of: BYTE, RF, or UNKNOWN.
+    /// @param band_index the index of the band to be returned as array.
+    /// @return the band as array.
+    void *get_band_as_array(int band_index);
+
     /// Return the total size of the data in bytes. Useful in conjunction with get_as_array.
     /// An optional pixel_size can be given if it deviates from the standard size saved in the
     /// object.
@@ -46,6 +64,13 @@ class GeoRaster {
 
     /// Return the format of the data of this GeoRaster.
     FORMAT get_format();
+
+    /// @brief get the FORMAT of the band at band_index within the dataset.
+    /// This function is most useful when working with either MIXED datasets or simply for
+    /// extracting specific band information
+    /// @param band_index index of the band whose format will be found
+    /// @return the FORMAT of the band at band_index
+    FORMAT get_band_format(int band_index);
 
     int get_pixel_size_x();
 
@@ -76,6 +101,10 @@ class GeoRaster {
     int destination_window_size_pixels;
 
     int interpolation_type;
+
+    /// Returns a RasterIOHelper with attributes needed for IO operations with native raster.
+    /// Internal function to extract data from native raster.
+    RasterIOHelper get_raster_io_helper();
 };
 
 #endif // RASTERTILEEXTRACTOR_GEORASTER_H

--- a/src/raster-tile-extractor/GeoRaster.h
+++ b/src/raster-tile-extractor/GeoRaster.h
@@ -11,12 +11,13 @@ class GDALDataset;
 /// Provides easy access without GDAL dependencies to library users.
 class GeoRaster {
   public:
-    enum FORMAT {
-        RGB,  // 3 8-bit int channels
-        RGBA, // 4 8-bit int channels
-        RF,   // 1 32-bit float channel
-        BYTE, // 1 8-bit int channel
-        UNKNOWN
+    enum FORMAT { // size (bits)    | data type         |   Number of chanels
+        RGB,      //    8           | int               |   3
+        RGBA,     //    8           | int               |   4
+        RF,       //    32          | float             |   X >= 1
+        BYTE,     //    8           | int               |   X >= 1
+        MIXED,    //    8<=X<=64    | int and/or float  |   X >= 2
+        UNKNOWN   //    unknown     | unknown           |   X >= 1
     };
 
     GeoRaster(GDALDataset *data, int interpolation_type);

--- a/src/vector-extractor/NativeDataset.cpp
+++ b/src/vector-extractor/NativeDataset.cpp
@@ -41,6 +41,20 @@ std::vector<std::string> NativeDataset::get_raster_layer_names() {
     return names;
 }
 
+std::vector<std::string> NativeDataset::get_raster_band_descriptions() {
+    std::vector<std::string> result;
+    if (!this->is_valid()) {
+        return result;
+    }
+    int total_raster_bands = this->dataset->GetRasterCount();
+    for (int i = 1; i < total_raster_bands + 1; i++) {
+        GDALRasterBand *band = this->dataset->GetRasterBand(i);
+        std::string description(band->GetDescription());
+        result.emplace_back(description);
+    }
+    return result;
+}
+
 std::shared_ptr<NativeLayer> NativeDataset::get_layer(const char *name) const {
     return std::make_shared<NativeLayer>(dataset->GetLayerByName(name));
 }

--- a/src/vector-extractor/NativeDataset.h
+++ b/src/vector-extractor/NativeDataset.h
@@ -14,6 +14,9 @@ class NativeDataset {
     /// Return the names of all raster layers as std::strings.
     std::vector<std::string> get_raster_layer_names();
 
+    /// Return the descriptions of all raster bands as std::strings.
+    std::vector<std::string> get_raster_band_descriptions();
+
     /// Returns the layer from this dataset with the given name, or null if there is no layer
     /// with that name.
     std::shared_ptr<NativeLayer> get_layer(const char *name) const;


### PR DESCRIPTION
1. Updated the demo `project.godot` and one import to latest stable version `4.1`.
2. Updated `.gitignore` to ignore `.godot` local folder, for when demos are run/checked.
3. Completed some of the `TODO`s that were present and deleted some that were no longer required.
4. Refactored `GeoRaster::get_as_array()` and `GeoImage::set_raster` so there is less code duplication (it is hopefully also more readable).
5. Added extra functions to `GeoDataset` and `GeoRasterLayer` to allow extracting individual bands.
### Added: 
- `GeoDataset::get_raster_band`
- `GeoDataset::get_raster_layers_by_band`
- `GeoDataset::get_raster_count`
- `GeoRasterLayer::get_band_image`
### Changed: 
- `GeoDataset::get_raster_layer` now has a second argument `band_index`, which can be mostly be ignored if no specific band is needed, when working with layers, but was added for correctness, so bands that are extracted (using `get_raster_layers`) still get correct indices set.
- `GeoRaster::FORMAT` `format` initialization got another addition for further completeness/correctness regarding a particular raster's intrinsic format. This is also not 100% in order to maintain backwards compatibility with projects relying on the particular `RGB(A)` settings that might be overwritten as `MIXED`. Otherwise this is more like added functionality than a change.
