### PR TITLE
feat: binary attributes on GeoFeatures

### DIFF
--- a/src/geofeatures.cpp
+++ b/src/geofeatures.cpp
@@ -6,7 +6,9 @@ using namespace godot;
 
 void GeoFeature::_bind_methods() {
     ClassDB::bind_method(D_METHOD("get_attribute", "name"), &GeoFeature::get_attribute);
+    ClassDB::bind_method(D_METHOD("get_binary_attribute", "name"), &GeoFeature::get_binary_attribute);
     ClassDB::bind_method(D_METHOD("set_attribute", "name", "value"), &GeoFeature::set_attribute);
+    ClassDB::bind_method(D_METHOD("set_binary_attribute", "name", "value"), &GeoFeature::set_binary_attribute);
     ClassDB::bind_method(D_METHOD("get_attributes"), &GeoFeature::get_attributes);
     ClassDB::bind_method(D_METHOD("get_id"), &GeoFeature::get_id);
     ClassDB::bind_method(D_METHOD("intersects_with", "other"), &GeoFeature::intersects_with);
@@ -18,9 +20,28 @@ String GeoFeature::get_attribute(String name) const {
     return String::utf8(gdal_feature->get_attribute(name.utf8().get_data()));
 }
 
+PackedByteArray GeoFeature::get_binary_attribute(String name) const
+{
+    PackedByteArray ret;
+    int n_bytes;
+    const uint8_t *bin_data = gdal_feature->get_binary_attribute(name.utf8().get_data(), &n_bytes);
+    ret.resize(n_bytes);
+    memcpy((void*) ret.ptr(), bin_data, n_bytes);
+    delete bin_data;
+    return ret;
+}
+
 void GeoFeature::set_attribute(String name, String value) {
     gdal_feature->set_attribute(name.utf8().get_data(), value.utf8().get_data());
     emit_signal("feature_changed");
+}
+
+void GeoFeature::set_binary_attribute(String name, PackedByteArray value)
+{
+    uint8_t *arr = new uint8_t[value.size()];
+    memcpy((void*)arr, value.ptr(), value.size());
+    gdal_feature->set_binary_attribute(name.utf8().get_data(), arr, (int) value.size());
+    delete[] arr;
 }
 
 int GeoFeature::get_id() const {

--- a/src/geofeatures.cpp
+++ b/src/geofeatures.cpp
@@ -20,14 +20,13 @@ String GeoFeature::get_attribute(String name) const {
     return String::utf8(gdal_feature->get_attribute(name.utf8().get_data()));
 }
 
-PackedByteArray GeoFeature::get_binary_attribute(String name) const
-{
+PackedByteArray GeoFeature::get_binary_attribute(String name) const {
     PackedByteArray ret;
     int n_bytes;
     const uint8_t *bin_data = gdal_feature->get_binary_attribute(name.utf8().get_data(), &n_bytes);
     ret.resize(n_bytes);
     memcpy((void*) ret.ptr(), bin_data, n_bytes);
-    delete bin_data;
+    delete[] bin_data;
     return ret;
 }
 
@@ -36,11 +35,11 @@ void GeoFeature::set_attribute(String name, String value) {
     emit_signal("feature_changed");
 }
 
-void GeoFeature::set_binary_attribute(String name, PackedByteArray value)
-{
+void GeoFeature::set_binary_attribute(String name, PackedByteArray value) {
     uint8_t *arr = new uint8_t[value.size()];
     memcpy((void*)arr, value.ptr(), value.size());
     gdal_feature->set_binary_attribute(name.utf8().get_data(), arr, (int) value.size());
+    emit_signal("feature_changed");
     delete[] arr;
 }
 

--- a/src/geofeatures.h
+++ b/src/geofeatures.h
@@ -26,7 +26,14 @@ class EXPORT GeoFeature : public Resource {
     virtual ~GeoFeature() = default;
 
     String get_attribute(String name) const;
+
+    ///Gets a binary data attribute as a PackedByteArray
+    PackedByteArray get_binary_attribute(String name) const;
+
     void set_attribute(String name, String value);
+
+    ///Sets a binary data attribute to the PackedByteArray provided
+    void set_binary_attribute(String name, PackedByteArray value);
 
     int get_id() const;
 

--- a/src/vector-extractor/Feature.cpp
+++ b/src/vector-extractor/Feature.cpp
@@ -1,4 +1,9 @@
 #include "Feature.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <ogr_feature.h>
+
 #include "gdal-includes.h"
 
 Feature::Feature(OGRFeature *feature) : feature(feature) {}
@@ -12,7 +17,8 @@ std::map<std::string, std::string> Feature::get_attributes() {
     std::map<std::string, std::string> ret;
 
     for (auto &&oField : *feature) {
-        ret[oField.GetName()] = oField.GetAsString();
+        if(oField.GetType() != OFTBinary)
+            ret[oField.GetName()] = oField.GetAsString();
     }
 
     return ret;
@@ -22,9 +28,27 @@ const char *Feature::get_attribute(const char *name) {
     return feature->GetFieldAsString(name);
 }
 
+
+const uint8_t *Feature::get_binary_attribute(const char *name, int* n_bytes)
+{
+    int field = feature->GetFieldIndex(name);
+    // temporary return value
+    GByte *data = feature->GetFieldAsBinary(field, n_bytes);
+    const auto ret = new uint8_t[*n_bytes];
+    std::copy_n(data, *n_bytes, ret);
+    return ret;
+}
+
 void Feature::set_attribute(const char *name, const char *value) {
     feature->SetField(name, value);
 }
+
+void Feature::set_binary_attribute(const char *name, uint8_t *value, int n_bytes)
+{
+    feature->SetField(feature->GetFieldIndex(name), n_bytes, value);
+    // where should the free happen?
+}
+
 
 int Feature::get_id() const {
     return feature->GetFID();

--- a/src/vector-extractor/Feature.cpp
+++ b/src/vector-extractor/Feature.cpp
@@ -29,8 +29,7 @@ const char *Feature::get_attribute(const char *name) {
 }
 
 
-const uint8_t *Feature::get_binary_attribute(const char *name, int* n_bytes)
-{
+const uint8_t *Feature::get_binary_attribute(const char *name, int* n_bytes) {
     int field = feature->GetFieldIndex(name);
     // temporary return value
     GByte *data = feature->GetFieldAsBinary(field, n_bytes);
@@ -43,10 +42,8 @@ void Feature::set_attribute(const char *name, const char *value) {
     feature->SetField(name, value);
 }
 
-void Feature::set_binary_attribute(const char *name, uint8_t *value, int n_bytes)
-{
+void Feature::set_binary_attribute(const char *name, uint8_t *value, int n_bytes) {
     feature->SetField(feature->GetFieldIndex(name), n_bytes, value);
-    // where should the free happen?
 }
 
 

--- a/src/vector-extractor/Feature.cpp
+++ b/src/vector-extractor/Feature.cpp
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <cstdint>
-#include <ogr_feature.h>
 
 #include "gdal-includes.h"
 

--- a/src/vector-extractor/Feature.h
+++ b/src/vector-extractor/Feature.h
@@ -5,6 +5,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <cstdint>
 
 class OGRFeature;
 class OGRGeometry;
@@ -30,7 +31,11 @@ class Feature {
     /// A field with the given name must exist.
     const char *get_attribute(const char *name);
 
+    const uint8_t *get_binary_attribute(const char *name, int *n_bytes);
+
     void set_attribute(const char *name, const char *value);
+
+    void set_binary_attribute(const char *name, uint8_t *value, int n_bytes);
 
     int get_id() const;
 


### PR DESCRIPTION
Getter and setter for BLOB attributes. Allows retrieval and storage of binary data on a feature by attribute name.

Setter function exposed to Godot emits feature_changed signal. 